### PR TITLE
Ran freeze.py in buildspacks/conda

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:05 UTC
+# Frozen on 2020-02-12 12:18:59 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.0=py_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
@@ -23,28 +23,27 @@ dependencies:
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
   - importlib_metadata=1.5.0=py37_0
-  - inflect=4.0.0=py37_1
   - ipykernel=5.1.4=py37h5ca1d4c_0
-  - ipython=7.11.1=py37h5ca1d4c_0
+  - ipython=7.12.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py37_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
+  - jinja2=2.11.1=py_0
+  - json5=0.9.0=py_0
   - jsonschema=3.2.0=py37_0
   - jupyter_client=5.3.4=py37_1
-  - jupyter_core=4.6.1=py37_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jupyter_core=4.6.2=py37_0
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
   - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
+  - libcurl=7.68.0=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.2.0=h24d8f2e_2
@@ -52,13 +51,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h516909a_0
   - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.2.0=py_0
   - nbconvert=5.6.1=py37_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=12.14.1=h67efad7_0
   - notebook=6.0.3=py37_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
@@ -66,10 +66,10 @@ dependencies:
   - pamela=1.0.0=py_0
   - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
+  - parso=0.6.1=py_0
   - pexpect=4.8.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=20.0.2=py37_0
+  - pip=20.0.2=py_2
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
@@ -90,23 +90,23 @@ dependencies:
   - ruamel.yaml=0.16.6=py37h516909a_0
   - ruamel.yaml.clib=0.2.0=py37h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py37_0
+  - setuptools=45.2.0=py37_0
   - six=1.14.0=py37_0
   - sqlalchemy=1.3.13=py37h516909a_0
   - sqlite=3.30.1=hcee41ef_0
   - terminado=0.8.3=py37_0
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py37h516909a_0
+  - tornado=6.0.3=py37h516909a_3
   - traitlets=4.3.3=py37_0
   - urllib3=1.25.7=py37_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py37_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py37_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-27 12:28:36 UTC
+# Frozen on 2020-02-12 12:16:53 UTC
 name: r2d
 channels:
   - conda-forge
@@ -22,7 +22,7 @@ dependencies:
   - ipython=5.8.0=py27_1
   - ipython_genutils=0.2.0=py_1
   - jupyter_client=5.3.4=py27_1
-  - jupyter_core=4.6.1=py27_0
+  - jupyter_core=4.6.2=py27_0
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
@@ -33,7 +33,7 @@ dependencies:
   - pathlib2=2.3.5=py27_0
   - pexpect=4.8.0=py27_0
   - pickleshare=0.7.5=py27_1000
-  - pip=20.0.2=py27_0
+  - pip=20.0.2=py_2
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py_1001
   - pygments=2.5.2=py_0
@@ -51,7 +51,7 @@ dependencies:
   - tornado=5.1.1=py27h14c3975_1000
   - traitlets=4.3.3=py27_0
   - wcwidth=0.1.8=py_0
-  - wheel=0.33.6=py27_0
+  - wheel=0.34.2=py_1
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:21 UTC
+# Frozen on 2020-02-12 12:17:39 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.0=py_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
@@ -23,27 +23,26 @@ dependencies:
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py36_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
   - importlib_metadata=1.5.0=py36_0
-  - inflect=4.0.0=py36_1
   - ipykernel=5.1.4=py36h5ca1d4c_0
-  - ipython=7.11.1=py36h5ca1d4c_0
+  - ipython=7.12.0=py36h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py36_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
+  - jinja2=2.11.1=py_0
+  - json5=0.9.0=py_0
   - jsonschema=3.2.0=py36_0
   - jupyter_client=5.3.4=py36_1
-  - jupyter_core=4.6.1=py36_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jupyter_core=4.6.2=py36_0
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py36_2
   - jupyterhub-singleuser=1.1.0=py36_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
-  - libcurl=7.65.3=hda55be3_0
+  - libcurl=7.68.0=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.2.0=h24d8f2e_2
@@ -51,13 +50,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py36h516909a_0
   - mistune=0.8.4=py36h516909a_1000
-  - more-itertools=8.2.0=py_0
   - nbconvert=5.6.1=py36_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=12.14.1=h67efad7_0
   - notebook=6.0.3=py36_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
@@ -65,10 +65,10 @@ dependencies:
   - pamela=1.0.0=py_0
   - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
+  - parso=0.6.1=py_0
   - pexpect=4.8.0=py36_0
   - pickleshare=0.7.5=py36_1000
-  - pip=20.0.2=py36_0
+  - pip=20.0.2=py_2
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
@@ -89,23 +89,23 @@ dependencies:
   - ruamel.yaml=0.16.6=py36h516909a_0
   - ruamel.yaml.clib=0.2.0=py36h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py36_0
+  - setuptools=45.2.0=py36_0
   - six=1.14.0=py36_0
   - sqlalchemy=1.3.13=py36h516909a_0
   - sqlite=3.30.1=hcee41ef_0
   - terminado=0.8.3=py36_0
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py36h516909a_0
+  - tornado=6.0.3=py36h516909a_3
   - traitlets=4.3.3=py36_0
   - urllib3=1.25.7=py36_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py36_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py36_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:54:21 UTC
+# Generated on 2020-02-12 12:17:39 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nodejs==12.*
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:05 UTC
+# Frozen on 2020-02-12 12:18:59 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.0=py_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
@@ -23,28 +23,27 @@ dependencies:
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
   - importlib_metadata=1.5.0=py37_0
-  - inflect=4.0.0=py37_1
   - ipykernel=5.1.4=py37h5ca1d4c_0
-  - ipython=7.11.1=py37h5ca1d4c_0
+  - ipython=7.12.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py37_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
+  - jinja2=2.11.1=py_0
+  - json5=0.9.0=py_0
   - jsonschema=3.2.0=py37_0
   - jupyter_client=5.3.4=py37_1
-  - jupyter_core=4.6.1=py37_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jupyter_core=4.6.2=py37_0
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
   - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
+  - libcurl=7.68.0=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.2.0=h24d8f2e_2
@@ -52,13 +51,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h516909a_0
   - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.2.0=py_0
   - nbconvert=5.6.1=py37_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=12.14.1=h67efad7_0
   - notebook=6.0.3=py37_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
@@ -66,10 +66,10 @@ dependencies:
   - pamela=1.0.0=py_0
   - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
+  - parso=0.6.1=py_0
   - pexpect=4.8.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=20.0.2=py37_0
+  - pip=20.0.2=py_2
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
@@ -90,23 +90,23 @@ dependencies:
   - ruamel.yaml=0.16.6=py37h516909a_0
   - ruamel.yaml.clib=0.2.0=py37h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py37_0
+  - setuptools=45.2.0=py37_0
   - six=1.14.0=py37_0
   - sqlalchemy=1.3.13=py37h516909a_0
   - sqlite=3.30.1=hcee41ef_0
   - terminado=0.8.3=py37_0
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py37h516909a_0
+  - tornado=6.0.3=py37h516909a_3
   - traitlets=4.3.3=py37_0
   - urllib3=1.25.7=py37_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py37_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py37_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:54:05 UTC
+# Generated on 2020-02-12 12:18:59 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nodejs==12.*
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.8.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:53:33 UTC
+# Frozen on 2020-02-12 12:20:09 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.0=py_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
@@ -23,28 +23,27 @@ dependencies:
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py38_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py38_1000
   - importlib_metadata=1.5.0=py38_0
-  - inflect=4.0.0=py38_1
   - ipykernel=5.1.4=py38h5ca1d4c_0
-  - ipython=7.11.1=py38h5ca1d4c_0
+  - ipython=7.12.0=py38h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py38_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
+  - jinja2=2.11.1=py_0
+  - json5=0.9.0=py_0
   - jsonschema=3.2.0=py38_0
   - jupyter_client=5.3.4=py38_1
-  - jupyter_core=4.6.1=py38_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jupyter_core=4.6.2=py38_0
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py38_2
   - jupyterhub-singleuser=1.1.0=py38_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
   - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
+  - libcurl=7.68.0=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.2.0=h24d8f2e_2
@@ -52,13 +51,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py38h516909a_0
   - mistune=0.8.4=py38h516909a_1000
-  - more-itertools=8.2.0=py_0
   - nbconvert=5.6.1=py38_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=12.14.1=h67efad7_0
   - notebook=6.0.3=py38_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
@@ -66,10 +66,10 @@ dependencies:
   - pamela=1.0.0=py_0
   - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
+  - parso=0.6.1=py_0
   - pexpect=4.8.0=py38_0
   - pickleshare=0.7.5=py38_1000
-  - pip=20.0.2=py38_0
+  - pip=20.0.2=py_2
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
@@ -90,23 +90,23 @@ dependencies:
   - ruamel.yaml=0.16.6=py38h516909a_0
   - ruamel.yaml.clib=0.2.0=py38h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py38_0
+  - setuptools=45.2.0=py38_0
   - six=1.14.0=py38_0
   - sqlalchemy=1.3.13=py38h516909a_0
   - sqlite=3.30.1=hcee41ef_0
   - terminado=0.8.3=py38_0
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py38h516909a_0
+  - tornado=6.0.3=py38h516909a_3
   - traitlets=4.3.3=py38_0
   - urllib3=1.25.7=py38_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py38_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py38_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.8.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:53:33 UTC
+# Generated on 2020-02-12 12:20:09 UTC
 dependencies:
 - python=3.8.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nodejs==12.*
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -4,5 +4,6 @@ dependencies:
   - jupyterlab==1.2.6
   - jupyterhub-singleuser==1.1.0
   - nbconvert==5.6.1
+  - nodejs==12.*
   - notebook==6.0.3
   - nteract_on_jupyter==2.1.3


### PR DESCRIPTION
@yuvipanda this regards https://github.com/jupyter/repo2docker/pull/847#issuecomment-583732554. I checked out your branch, entered repo2docker/buildpacks/conda, and ran `freeze.py`. It led to the following changes, and I also noted the following error come up while doing so.

This is to me not yet understood magic, so I hope you or @zsailer could make sense of it. The error below occurred three times, once for py-3.6, py-3.7, and py-3.8 associated with running `conda env create -v -f /r2d/environment.py-3.7.yml -n r2d`.

```
===> LINKING PACKAGE: conda-forge::jupyterlab-1.2.6-py_0 <===
  prefix=/opt/conda/envs/r2d
  source=/opt/conda/pkgs/jupyterlab-1.2.6-py_0


b'Enabling notebook extension jupyter-js-widgets/extension...\n      - Validating: \x1b[32mOK\x1b[0m\n'
pyc file failed to compile successfully (run_command failed)
python_exe_full_path: /opt/conda/envs/r2d/bin/python3.7
py_full_path: /opt/conda/envs/r2d/lib/python3.7/site-packages/pip/_internal/index/collector.py
pyc_full_path: /opt/conda/envs/r2d/lib/python3.7/site-packages/jupyter_telemetry/sphinxext/__pycache__/main.cpython-37.pyc
compile rc: 1
compile stdout: *** Error compiling 'lib/python3.7/site-packages/jupyter_telemetry/sphinxext/main.py'...
  File "lib/python3.7/site-packages/jupyter_telemetry/sphinxext/main.py", line 2
    from docutils import
                       ^
SyntaxError: invalid syntax


compile stderr: 


done
#
# To activate this environment, use
#
#     $ conda activate r2d
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```